### PR TITLE
Resend current state when receiving invalid sequence number

### DIFF
--- a/inc/HopeRF/RxTxState.hpp
+++ b/inc/HopeRF/RxTxState.hpp
@@ -124,6 +124,8 @@ public:
                 }
             } else {
                 log::debug(F("Invalid seqnr. Got "), dec(packet.seq), F(" expected "), dec(seq + 1));
+                resendCount = 0;
+                sendState();
                 return false;
             }
         }


### PR DESCRIPTION
This way, we should eventually end up in sync again with the Spark side.