### PR TITLE
Some clarification regarding power management while using USART

### DIFF
--- a/inc/HAL/Atmel/Usart.hpp
+++ b/inc/HAL/Atmel/Usart.hpp
@@ -15,6 +15,13 @@ using namespace Registers;
  * Configures the USART to use the given baud rate, and configures both pins (0 and 1) as transmitter
  * and receiver, respectively. If only one of them is to be used for USART, you can call Pin.configureAsGPIO() after
  * this method on either of them.
+ * 
+ * When transmitting over USART AVR core should be powered up or in
+ * IDLE state. Failing to do shut down UART transmitter and results
+ * in a framing errors. So you must either:
+ * 
+ * - spin-wait after write using `flush()` method;
+ * - have at least one task with `SleepMode::IDLE`.
  *
  * Also enables interrupts.
  */


### PR DESCRIPTION
Hello!

First of all thank you for your work. IMO it's one of the most compelling approaches to write modular and type-safe code for AVR.

I've lost several days trying to diagnose framing errors while using USART. It turns out, USART only works while AVR core is powered up or in IDLE state (see. section `9.1 Sleep Modes` in [datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7810-Automotive-Microcontrollers-ATmega328P_Datasheet.pdf)).

Other than USART my firmware contains only simple periodic ADC measurement several times a second. So after a ADC measurement AVR core goes to power down. USART is disabled and framing errors occurs.

Basically there is two options I've found:

* add spin-wait using `usartPin.flush()` which is used in most of examples in https://github.com/jypma/AvrLibDemo/;
* have at least one task with `IDLE` power state.

I've added some clarification in `Usart` class documentation if you don't mind. Hope this will save some time for someone in the future :)